### PR TITLE
Adding another receiver of the tweet stream update

### DIFF
--- a/src/lib/twitter.js
+++ b/src/lib/twitter.js
@@ -22,6 +22,10 @@ tstream.on('tweet', (tweet) => {
 
   channel = client.channels.get('766449729562738728'); // Lusternia Official, twitter
   if (channel) channel.send(msg);
+  
+  // Send direct to user
+  user = client.users.get('179096562809569282').send(msg);
+  /* This could be extended to use a file to store user ids of individuals wanting direct message updates */
 
   /*channel = client.channels.get('378176979826114562'); // Selune, bot-tomfoolery
   if (channel) channel.send(msg);*/


### PR DESCRIPTION
Wasn't sure how to test this since I can't host the bot and it'd be work to get it on my dev server to try it out.. So hopefully it works. It should.

I wasn't sure if I needed to do an if check for user like is done for the channels, but could easily add that in if it's necessary/works.

Should I be worried about storing my personal user id in here? I don't accept messages from people I don't share a server with.

Thanks for letting me propose an edit! -Cthulhu from discord